### PR TITLE
Refactor plugin config for lolcommits 0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/lolsrv/version.rb
+++ b/lib/lolcommits/lolsrv/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Lolsrv
-    VERSION = "0.0.4".freeze
+    VERSION = "0.0.5".freeze
   end
 end

--- a/lib/lolcommits/plugin/lolsrv.rb
+++ b/lib/lolcommits/plugin/lolsrv.rb
@@ -6,15 +6,6 @@ module Lolcommits
     class Lolsrv < Base
 
       ##
-      # Returns the name of the plugin. Identifies the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'lolsrv'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Sync/uploading happens when a new capture is ready.
       #
@@ -33,7 +24,7 @@ module Lolcommits
       # configured
       #
       def valid_configuration?
-        !!(configuration['server'] =~ /^http(s)?:\/\//)
+        !!(configuration[:server] =~ /^http(s)?:\/\//)
       end
 
       ##
@@ -43,9 +34,9 @@ module Lolcommits
       #
       def configure_options!
         options = super
-        if options['enabled']
+        if options[:enabled]
           print "server: "
-          options.merge!('server' => parse_user_input(gets.strip))
+          options.merge!(server: parse_user_input(gets.strip))
           puts '---------------------------------------------------------------'
           puts '  Lolsrv - Sync lolcommits to a remote server'
           puts ''
@@ -177,7 +168,7 @@ module Lolcommits
       # @return [String] `server` config option + '/uplol'
       #
       def upload_endpoint
-        configuration['server'] + '/uplol'
+        configuration[:server] + '/uplol'
       end
 
       ##
@@ -189,7 +180,7 @@ module Lolcommits
       # @return [String] `server` config option + '/lols'
       #
       def lols_endpoint
-        configuration['server'] + '/lols'
+        configuration[:server] + '/lols'
       end
     end
   end

--- a/lolcommits-lolsrv.gemspec
+++ b/lolcommits-lolsrv.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.7"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version for new plugin release